### PR TITLE
cci integration, and make it pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,55 @@
+version: 2.1
+
+# use circleci's pipeline argument to ease configuration.
+# this allows you to track the right packages, and to add extra dependencies if needed
+# just change the default here
+parameters:
+  pc-repo:
+    description: the packagecloud repository to find the Varnish Cache packages. It should match the version you are building against
+    type: string
+    default: "varnish-weekly"
+  dep-pkgs:
+    description: which packages to install to build your vmod(s)
+    type: string
+    default: "make automake libtool python-sphinx"
+
+# for now, we just build for centos:7, be we can do it for more platforms if needed
+jobs:
+  build:
+    docker:
+      - image: centos:7
+    working_directory: /workspace
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            curl -s https://packagecloud.io/install/repositories/varnishcache/<< pipeline.parameters.pc-repo >>/script.rpm.sh | bash
+            yum install -y epel-release
+            yum install -y git varnish-devel << pipeline.parameters.dep-pkgs >>
+      - checkout
+      - run:
+          name: Build and test
+          command: |
+            ./autogen.sh
+            ./configure
+            make
+            make check -j 4
+            make install
+
+# two workflows, identical but for their triggers ()commit/scheduled
+workflows:
+  version: 2
+  # run the build job for all commits
+  commit: &jobs
+    jobs:
+      - build
+  # every week, run build too, in case packages got updated
+  nightly:
+    <<: *jobs
+    triggers:
+      - schedule:
+          cron: "0 4 * * *"
+          filters:
+            branches:
+              only:
+                - master

--- a/README.rst
+++ b/README.rst
@@ -125,3 +125,5 @@ The basic steps to start a new vmod from this example are::
   ./rename-vmod-script $name
 
 and follow the instructions output by rename-vmod-script
+
+[![CircleCI](https://circleci.com/gh/varnishcache/libvmod-example/tree/master.svg?style=svg)](https://app.circleci.com/pipelines/github/varnishcache/libvmod-example?branch=master)

--- a/rename-vmod-script
+++ b/rename-vmod-script
@@ -34,6 +34,7 @@ git mv src/vmod_example.vcc src/vmod_${SYM_NAME}.vcc
 git grep -z -l example | xargs -0 sed -i -s -e "s/example/${SYM_NAME}/g"
 git grep -z -l Example | xargs -0 sed -i -s -e "s/Example/${CAP_NAME}/g"
 git grep -z -l EXAMPLE | xargs -0 sed -i -s -e "s/EXAMPLE/${UPP_NAME}/g"
+sed -i '/\[\!\[CircleCI\]/d' README.rst
 
 git rm -f rename-vmod-script
 

--- a/src/vmod_example.c
+++ b/src/vmod_example.c
@@ -69,7 +69,7 @@ vmod_hello(VRT_CTX, VCL_STRING name)
 	char *p;
 	unsigned u, v;
 
-	u = WS_Reserve(ctx->ws, 0); /* Reserve some work space */
+	u = WS_ReserveAll(ctx->ws); /* Reserve some work space */
 	p = ctx->ws->f;		/* Front of workspace area */
 	v = snprintf(p, u, "Hello, %s", name);
 	v++;


### PR DESCRIPTION
it would be nice for people forking this repository (even though vcdk exists) had a template for ci. The first commit add commit-triggered and weekly commits. And the second updates the code to make said tests pass.